### PR TITLE
Fixed Compatibility Issues with Sublime Linter 4.12

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,12 +17,17 @@ class Xvhdl(Linter):
 
     """Provides an interface to xvhdl (from Xilinx Vivado Simulator)."""
 
-    syntax = 'vhdl'
+    name = 'xvhdl'
     cmd = 'xvhdl @'
-    version_args = '--version --nolog'
-    version_re = r'Vivado Simulator (?P<version>\d+\.\d+)'
-    version_requirement = '>= 2014.4'
-    tempfile_suffix = 'vhd'
+    defaults = {
+        'selector': 'source.vhdl',
+    }
+
+    # the following attributes are marked useless for SL4
+    #version_args = '--version --nolog'
+    #version_re = r'Vivado Simulator (?P<version>\d+\.\d+)'
+    #version_requirement = '>= 2014.4'
+    #tempfile_suffix = 'vhd'
 
     # Here is a sample xvhdl error output:
     # ----8<------------


### PR DESCRIPTION
Solved the issue: https://github.com/BrunoJJE/SublimeLinter-contrib-xvhdl/issues/3
SublimeLinter: ERROR: xvhdl: Defining 'cls.syntax' has no effect anymore. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector instead.
SublimeLinter: ERROR: xvhdl disabled. 'cls.defaults' is mandatory and MUST be a dict.