### PR TITLE
Updated to support latest SublimeLinter release

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,16 +18,17 @@ class Xvhdl(Linter):
     """Provides an interface to xvhdl (from Xilinx Vivado Simulator)."""
 
     name = 'xvhdl'
-    cmd = 'xvhdl @'
+    cmd = 'xvhdl ${file}'
     defaults = {
-        'selector': 'source.vhdl',
+        'selector': 'source.vhdl, source.vhd',
     }
+    tempfile_suffix = 'vhd'
 
     # the following attributes are marked useless for SL4
     #version_args = '--version --nolog'
     #version_re = r'Vivado Simulator (?P<version>\d+\.\d+)'
     #version_requirement = '>= 2014.4'
-    #tempfile_suffix = 'vhd'
+    
 
     # Here is a sample xvhdl error output:
     # ----8<------------


### PR DESCRIPTION
The use of @ in the 'cmd' variable has been deprecated.

Added the .vhd alternative extension to the selector

XVHDL does not support data ingest through stdin, therefore a tempfile_suffix must be specified.